### PR TITLE
Fix the Docker container error caused by missing CUDNN8 dynamic library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,29 @@
 # Use an NVIDIA CUDA base image with Python 3
-FROM nvidia/cuda:11.6.2-base-ubuntu20.04 
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
+
+ENV PYTHON_VERSION=3.10
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
-# Copy the requirements.txt file first to leverage Docker cache
-COPY requirements.txt ./
-
 # Avoid interactive prompts from apt-get
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install any needed packages specified in requirements.txt
-RUN apt-get update && apt-get install -y python3-pip libsndfile1 ffmpeg && \
-    pip3 install --no-cache-dir -r requirements.txt
+# Install any needed packages
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -qq update \
+    && apt-get -qq install \
+                   ffmpeg \
+                   libsndfile1 \
+                   python3-pip \
+                   python${PYTHON_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
 
-# Reset the frontend (not necessary in newer Docker versions)
-ENV DEBIAN_FRONTEND=newt
+# Copy the requirements.txt file
+COPY requirements.txt requirements.txt
+
+# Install any needed packages specified in requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Copy the rest of your application's code
 COPY . .
@@ -31,4 +39,3 @@ ENTRYPOINT ["python3", "-m", "src.main"]
 
 # Provide a default command (can be overridden at runtime)
 CMD ["--host", "0.0.0.0", "--port", "8765"]
-


### PR DESCRIPTION
fix #17 

The major version of CUDNN in the latest CUDA image has been upgraded to version 9, so the image used in the current PR is not the latest one. 